### PR TITLE
Fix calls to gpg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,8 @@ ARG TINI_VERSION=v0.16.1
 COPY tini_pub.gpg ${JENKINS_HOME}/tini_pub.gpg
 RUN curl -fsSL https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static-$(dpkg --print-architecture) -o /sbin/tini \
   && curl -fsSL https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static-$(dpkg --print-architecture).asc -o /sbin/tini.asc \
-  && gpg --import ${JENKINS_HOME}/tini_pub.gpg \
-  && gpg --verify /sbin/tini.asc \
+  && gpg --batch --no-tty --import ${JENKINS_HOME}/tini_pub.gpg \
+  && gpg --batch --no-tty --verify /sbin/tini.asc /sbin/tini \
   && rm -rf /sbin/tini.asc /root/.gnupg \
   && chmod +x /sbin/tini
 


### PR DESCRIPTION
Recent changes to gpg caused different interaction with the TTY. This
causes issues when run in a Dockerfile. See also
https://github.com/docker-library/postgres/issues/526

The datafile target of the `gpg --verify` call was missing as well.